### PR TITLE
fixed bug in tempo argument and added host sync/transport infos

### DIFF
--- a/source/apps/clap-host/main.cpp
+++ b/source/apps/clap-host/main.cpp
@@ -137,7 +137,11 @@ int main(int argc, char** argv) {
   arg_block_size        = arg_parser.getArgInt(                  "-b",   "--block_size");
   arg_num_audio_inputs  = arg_parser.getArgInt(                  "-c",   "--channels");
   arg_num_audio_outputs = arg_parser.getArgIntAfterSymbol( ':',  "-c",   "--channels");
-  arg_tempo             = arg_parser.getArgFloat(                "-t",   "--tempo");
+    
+  if (arg_parser.hasOption("-t","--tempo")) {
+    arg_tempo             = arg_parser.getArgFloat(                "-t",   "--tempo");
+  }
+      
   arg_decay_seconds     = arg_parser.getArgFloat(                "-d",   "--decay-seconds");
 
   arg_list_plugins      = arg_parser.hasOption(                  "-pl",  "--list-plugins");

--- a/source/apps/clap-host/process.hpp
+++ b/source/apps/clap-host/process.hpp
@@ -187,10 +187,16 @@ private:
 
     double speedFactor = tempo / 60.0;
     double beatsPosFloat = MCurrentTime * speedFactor;
-
-    //printf("prepare_transport: beatsPosFloat: %f\n", beatsPosFloat);
+      
+    /*
+    printf("prepare_transport: tempo: %f\n", tempo);
+    printf("prepare_transport: MCurrentTime: %f\n", MCurrentTime);
+    printf("prepare_transport: beatsPosFloat: %f\n", beatsPosFloat);
+    printf("prepare_transport: barStart: %f\n", beatsPosFloat - fmod(beatsPosFloat, 4.0));
+     */
 
     clap_beattime bTime = round(CLAP_BEATTIME_FACTOR * beatsPosFloat);
+    clap_beattime barStart = CLAP_BEATTIME_FACTOR * (beatsPosFloat - fmod(beatsPosFloat, 4.0));
 
     MContextTransport.header.size = sizeof(clap_event_transport);
     MContextTransport.header.time         = 0;
@@ -202,8 +208,8 @@ private:
     MContextTransport.song_pos_seconds    = 0;
     MContextTransport.tempo               = tempo;
     MContextTransport.tempo_inc           = 0.0;
-    MContextTransport.bar_start           = 0;
-    MContextTransport.bar_number          = 0;
+    MContextTransport.bar_start           = barStart;
+    MContextTransport.bar_number          = (int)(beatsPosFloat/4);
     MContextTransport.loop_start_beats    = 0;
     MContextTransport.loop_end_beats      = 0;
     MContextTransport.loop_start_seconds  = 0;

--- a/source/apps/clap-host/process.hpp
+++ b/source/apps/clap-host/process.hpp
@@ -187,16 +187,10 @@ private:
 
     double speedFactor = tempo / 60.0;
     double beatsPosFloat = MCurrentTime * speedFactor;
-      
-    /*
-    printf("prepare_transport: tempo: %f\n", tempo);
-    printf("prepare_transport: MCurrentTime: %f\n", MCurrentTime);
-    printf("prepare_transport: beatsPosFloat: %f\n", beatsPosFloat);
-    printf("prepare_transport: barStart: %f\n", beatsPosFloat - fmod(beatsPosFloat, 4.0));
-     */
+
+    //printf("prepare_transport: beatsPosFloat: %f\n", beatsPosFloat);
 
     clap_beattime bTime = round(CLAP_BEATTIME_FACTOR * beatsPosFloat);
-    clap_beattime barStart = CLAP_BEATTIME_FACTOR * (beatsPosFloat - fmod(beatsPosFloat, 4.0));
 
     MContextTransport.header.size = sizeof(clap_event_transport);
     MContextTransport.header.time         = 0;
@@ -208,8 +202,8 @@ private:
     MContextTransport.song_pos_seconds    = 0;
     MContextTransport.tempo               = tempo;
     MContextTransport.tempo_inc           = 0.0;
-    MContextTransport.bar_start           = barStart;
-    MContextTransport.bar_number          = (int)(beatsPosFloat/4);
+    MContextTransport.bar_start           = 0;
+    MContextTransport.bar_number          = 0;
     MContextTransport.loop_start_beats    = 0;
     MContextTransport.loop_end_beats      = 0;
     MContextTransport.loop_start_seconds  = 0;


### PR DESCRIPTION
tempo was set to 0 if no tempo argument was passed via the commandline and no midi file was passed to read the bpm from. bad thing for applying beat synced FX to audio input.
added timing event infos for bar start and bar number.. it's still a bit dummy code because it always assumes 4/4 time but better then not having any info ;)